### PR TITLE
rename "ibm push" to "push notifications"

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -35,7 +35,7 @@
 #       - Compose for MySQL
 #       - Compose for PostgreSQL
 #       - App ID
-#       - IBM Push
+#       - Push Notifications
 #       - Streaming Analytics for Bluemix
 #       - Investment Portfolio
 #       - Predictive Market Scenarios


### PR DESCRIPTION
cause that's what it's actually named https://console.bluemix.net/catalog/services/push-notifications?env_id=ibm%3Ayp%3Aus-south&taxonomyNavigation=apps